### PR TITLE
CLI: Check for array values first in `includeCharacters` schema

### DIFF
--- a/glypht-cli/src/schema.ts
+++ b/glypht-cli/src/schema.ts
@@ -39,7 +39,7 @@ const FamilySubsetSettingsSchema = v.variant('enableSubsetting', [
         styleValues: v.record(v.string(), SubsetAxisSettingSchema),
         axes: v.record(v.string(), SubsetAxisSettingSchema),
         features: v.optional(v.record(v.string(), v.boolean())),
-        includeCharacters: v.union([CharacterSetSettingsSchema, v.array(CharacterSetSettingsSchema), v.literal('all')]),
+        includeCharacters: v.union([v.array(CharacterSetSettingsSchema), CharacterSetSettingsSchema, v.literal('all')]),
         overrideName: v.optional(v.string()),
     }),
     v.object({


### PR DESCRIPTION
I was having trouble getting the glypht CLI to generate separate subset files, and it seems that the config was not being parsed correctly.

Since all the values of CharacterSetSettingsSchema are [now optional](https://github.com/valadaptive/glypht/commit/17cdaeb8b96660199a447dce769f159e51a34b69), valibot's `safeParse` appears to process array values as empty objects. I assume because with no properties to check, an array fits as an object. In this PR, I've switched around the order of types so that the array variation of `includeCharacters` is checked first, this correctly parses out the array values while still parsing out the single object value when it exists.

Here's a reduced [test case using the valibot playground](https://valibot.dev/playground/?code=JYWwDg9gTgLgBAKjgQwM5wG5wGZQiOAcg2QBtgAjCGQgbgCh6BjCAO1XgGEALZKZJjACmUAMpCY4mDGCsA5qlFNuQkMjgBeTADoIFAFZDBACgDe9OJbiympAK4ATIQFVWwFk4BKyeUNQAuHQgwGTYyYwsrKIxtOzc2YwBtGI4oWTljAEoAGh0%20fgBPYxi44ATk7VY7EAoRLNyYmDswUiEkmKqaupydTtqoLIBdTOGRzJzIy1ZkECFAmODQ6dJi7VT0rImAX0yGZjYOOCUVNU0ggyMYM0ibeycePgFhKACdUvLJuAf%20QREpKRk8kUylUyGynxi%20WQRW%20Tz%20EgB6WBJ2QE2i2nIz3ChDIpEImUiw3BOz2LHY8GOoIATGcFhcTOZLLdHEJYb8XvNYvFWEkIdooTDeD9nv8JICFJS1GirGyRQixUjJWC%20ZiRNjcfjCdtdowyagIK0MRAMgAiTh2KBQISseCoEFqfwmnX7dgGoRGjIpZDYIQABT4qDaStyjOsrFsLNlIleiVMzKcrncEC8PjkfkdzgA1ABGAC0ABYAJwmrbZOPhu4uNweITeXwBE1ZgDMTapuaphapJcGxPGpIObo9xjNKiYAGscNAUJboThgC8YI7nXrB6RjatUN6-QGg-bkFSQzcK5GhXCOXBY-Gq0mU-WMzmC8XS%20WIwnq8na6n043My22x2uy2Ht6B2HUgA), showing both the current issue and this fix.

I've also attached my glypht config which has two `includeCharacters` variations.

<details>
<summary>My config file</summary>

```ts
import type { GlyphtConfig } from "@glypht/cli";

const config: GlyphtConfig = {
    input: ["NotoSerifKR-VF.ttf"],
    outDir: "assets/fonts",
    formats: {
        ttf: false,
        woff: false,
        woff2: true,
    },
    woff2Compression: 11,
    settings: {
        "Noto Serif KR": {
            enableSubsetting: true,
            axes: {
                wght: {
                    type: "variable",
                    value: { min: 200, max: 900 },
                },
            },
            styleValues: {
                weight: {
                    type: "variable",
                    value: { min: 200, max: 900 },
                },
            },
            features: {
                chws: true, // Contextual Half-width Spacing
                halt: true, // Alternate Half Widths
                kern: true, // Kerning
                palt: false, // Proportional Alternate Widths
                vchw: true, // Vertical Contextual Half-width Spacing
                vhal: true, // Alternate Vertical Half Widths
                vkrn: true, // Vertical Kerning
                vpal: true, // Proportional Alternate Vertical Metrics
                aalt: false, // Access All Alternates
                calt: true, // Contextual Alternates
                dlig: false, // Discretionary Ligatures
                fwid: false, // Full Widths
                hist: false, // Historical Forms
                hwid: false, // Half Widths
                liga: true, // Standard Ligatures
                pwid: false, // Proportional Widths
                ruby: false, // Ruby Notation Forms
                vrt2: true, // Vertical Alternates and Rotation
            },
            includeCharacters: [
                { includeNamedSubsets: ["korean"] },
                { includeNamedSubsets: ["latin"] },
            ],
        },
    },
};

export default config;
```
</details>